### PR TITLE
Fix CI bugs and update unsupported config option

### DIFF
--- a/.github/workflows/model_ci.yml
+++ b/.github/workflows/model_ci.yml
@@ -68,7 +68,7 @@ jobs:
 
     - name: Post cross-val results to PR
       if: steps.cvnlu.outcome == 'success'
-      uses: amn41/comment-on-pr@comment-file-contents
+      uses: samsucik/comment-on-pr@comment-file-contents
       continue-on-error: true
       with:
         msg: results.md

--- a/.github/workflows/model_ci.yml
+++ b/.github/workflows/model_ci.yml
@@ -43,7 +43,7 @@ jobs:
 
     - name: Run Through Test Stories
       run: |
-        rasa test core --stories test_stories/stories.yaml --fail-on-prediction-errors
+        rasa test core --stories test_stories/stories.yml --fail-on-prediction-errors
 
     - name: Cross-validate NLU model
       id: cvnlu

--- a/config.yml
+++ b/config.yml
@@ -14,7 +14,7 @@ pipeline:
 - name: DIETClassifier
   epochs: 60
   scale_loss: False
-  weight_sparsity: 0.3
+  connection_density: 0.7
   transformer_size: 512
   BILOU_flag: True
 - name: ResponseSelector

--- a/test_stories/stories.yml
+++ b/test_stories/stories.yml
@@ -20,6 +20,9 @@ stories:
   - intent: greet
   - action: utter_SCENARIOCHECK
   - intent: SCENARIO
+    entities:
+    - context_scenario: holiday
+    - holiday_name: thanksgiving  
   - slot_was_set:
     - context_scenario: holiday
     - holiday_name: thanksgiving
@@ -71,6 +74,9 @@ stories:
   - intent: greet
   - action: utter_SCENARIOCHECK
   - intent: SCENARIO
+    entities:
+    - context_scenario: holiday
+    - holiday_name: christmas
   - slot_was_set:
     - context_scenario: holiday
   - slot_was_set:
@@ -116,6 +122,9 @@ stories:
 - story: filling travel plan before airtravel_form
   steps:
   - intent: SCENARIO
+    entities:
+    - context_scenario: holiday
+    - holiday_name: thanksgiving
   - slot_was_set:
     - context_scenario: holiday
   - slot_was_set:
@@ -152,6 +161,9 @@ stories:
   - intent: greet
   - action: utter_SCENARIOCHECK
   - intent: SCENARIO
+    entities:
+    - context_scenario: holiday
+    - holiday_name: christmas
   - slot_was_set:
     - context_scenario: holiday
     - holiday_name: christmas
@@ -194,6 +206,9 @@ stories:
   - intent: greet
   - action: utter_SCENARIOCHECK
   - intent: SCENARIO
+    entities:
+    - context_scenario: holiday
+    - holiday_name: christmas
   - slot_was_set:
     - context_scenario: holiday
   - slot_was_set:


### PR DESCRIPTION
Previously, the CI was running on training stories because it couldn't find the test story file. This is now fixed.

Additionally, CI didn't report the NLU cross-validation results when a new PR was opened -- one had to add further commits in order to get the report posted as a comment on the PR. This is now fixed as well.

Also, DIET was using a config option that's no longer supported (`weight_sparsity`), I've changed this to use `connection_density`.