### PR TITLE
Add basic response to use in action fallback.

### DIFF
--- a/domain.yml
+++ b/domain.yml
@@ -264,6 +264,8 @@ responses:
   - text: What would you do if someone said that to someone you care about?
   - text: What if someone said that to you?
   - text: If someone said that to you, what would you say to them?
+  utter_default:
+  - text: Sorry I didn't get that. Can you rephrase?
 actions:
 - action_analyse_travelplan
 - action_calculate_offsets


### PR DESCRIPTION
Action fallback is currently enabled but doesn't have a corresponding bot response defined. Then, the bot fails to choose next action but doesn't explain this to the user. By adding a response, we make the bot behave in a much more intuitive way. Part of [research/#266](https://github.com/RasaHQ/research/issues/266).