### PR TITLE
Make DIET and ResponseSelector use fixed random seeds

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -12,12 +12,14 @@ pipeline:
 - name: RegexFeaturizer
 - name: LexicalSyntacticFeaturizer
 - name: DIETClassifier
+  random_seed: 666
   epochs: 60
   scale_loss: False
   connection_density: 0.7
   transformer_size: 512
   BILOU_flag: True
 - name: ResponseSelector
+  random_seed: 666
   epochs: 50
 - name: EntitySynonymMapper
 


### PR DESCRIPTION
It's useful to have multiple versions of the bot as consistent with each other as possible. Hence, we should use fixed random seeds where possible, in order to prevent unnecessary determinism in the bot's ML models (`TEDPolicy`, `DIETClassifier`, `ResponseSelector`).